### PR TITLE
don't use per-cpu stats

### DIFF
--- a/pixelload/backend/cpu.py
+++ b/pixelload/backend/cpu.py
@@ -1,16 +1,18 @@
 import psutil
 import numpy as np
 
+def cpu_times():
+    data = psutil.cpu_times_percent(percpu=False)
+    return [data.user + data.steal, data.nice, data.irq + data.softirq + data.system, data.iowait]
 
 def start(width):
-    data = psutil.cpu_percent(percpu=True)
-    num_cpu = len(data)
-    hist = [[0] * num_cpu] * width
+    num_elems = len(cpu_times())
+    hist = [[0] * num_elems] * width
     while True:
-        data = psutil.cpu_percent(percpu=True)
+        data = cpu_times()
         hist.append(data)
         hist.pop(0)
-        result = np.asarray(hist) / 100 / num_cpu
+        result = np.asarray(hist) / 100
         yield result
 
 

--- a/plasmoid/contents/config/main.xml
+++ b/plasmoid/contents/config/main.xml
@@ -23,16 +23,16 @@
   <group name="Colors">
 
     <entry name="colorCpu0" type="Color">
-      <default>#00ffff</default>
+      <default>#004cff</default>
     </entry>
     <entry name="colorCpu1" type="Color">
-      <default>#ff00ff</default>
+      <default>#5ce4ff</default>
     </entry>
     <entry name="colorCpu2" type="Color">
-      <default>#0000ff</default>
+      <default>#ffec58</default>
     </entry>
     <entry name="colorCpu3" type="Color">
-      <default>#00ff00</default>
+      <default>#ff0000</default>
     </entry>
 
     <entry name="colorMem0" type="Color">


### PR DESCRIPTION
On a 4-core machine with hardware 8 threads the per-cpu setting made things totally unreadable.